### PR TITLE
Fix wrong directory name

### DIFF
--- a/_posts/2023-07-31-running-arch-linux-on-the-framework-laptop-13.md
+++ b/_posts/2023-07-31-running-arch-linux-on-the-framework-laptop-13.md
@@ -1007,7 +1007,7 @@ cd "$PKG_ROOT/Repository"
 pacman -Qpi aurutils-*-any.pkg.tar.zst
 
 # Build a source package.
-cd aurutils
+cd ../Build/aurutils
 makepkg -cCsS
 ls ../../Source\ Packages
 


### PR DESCRIPTION
Trying to run this cd command resulted in an error - I imagine it's `../Build/aurutils` that's intended to be used.

```
$ cd ~/Packaging/Arch && find -maxdepth 2 -print | sed -e 's;[^/]*/;|____;g;s;____|; |;g'
.
|____Build
| |____aurutils
|____Repository
| |____custom.db.tar.gz
| |____custom.db
| |____custom.files.tar.gz
| |____custom.files
| |____aurutils-20.4-1-any.pkg.tar.zst
|____Source Packages
| |____aurutils-20.4-1.src.tar.gz
|____Sources
| |____aurutils-20.4.tar.gz
```